### PR TITLE
fix: add ctex for Chinese text in PDF export

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -1,3 +1,4 @@
+\usepackage[UTF8]{ctex}
 \usepackage{booktabs}
 \usepackage{amsthm}
 \makeatletter


### PR DESCRIPTION
### Motivation
- Ensure Chinese text renders correctly in PDF exports produced by the bookdown pipeline using XeLaTeX.

### Description
- Added `\usepackage[UTF8]{ctex}` to the top of `preamble.tex` so `bookdown::pdf_book` (with `xelatex`) can properly handle Chinese characters.

### Testing
- Attempted to run `Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"`, but the environment does not have `R`/`Rscript` installed so the full build could not be executed; also ran `which R || which Rscript || which quarto || which pandoc` which returned no tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699073353a548330a9af74a1966bcb3f)